### PR TITLE
Add few fonctionality

### DIFF
--- a/commands/startCounter.js
+++ b/commands/startCounter.js
@@ -1,0 +1,19 @@
+const { SlashCommandBuilder } = require('discord.js');
+const { getCounter, setCounter } = require('../utils/counter');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('startcounter')
+        .setDescription('Démarrer le jeu de compteur dans un salon spécifique.')
+        .addChannelOption(option =>
+            option.setName('channel')
+                .setDescription('Le salon où démarrer le jeu.')
+                .setRequired(true)
+                .addChannelTypes(0)), // 0 for GUILD_TEXT
+    async execute(interaction) {
+        const channel = interaction.options.getChannel('channel');
+        setCounter(0, null);
+
+        await interaction.reply(`Le jeu de compteur a démarré dans le salon <#${channel.id}>. Le compteur est à 0.`);
+    },
+};

--- a/exemple_config.json
+++ b/exemple_config.json
@@ -1,8 +1,0 @@
-{
-    "token": "your_discord_bot_token",
-    "clientId": "your_discord_client_id",
-    "blueskyHandle": "your_bluesky_handle",
-    "blueskyAppPassword": "your_bluesky_app_password",
-    "twitchClientId": "your_twitch_client_id",
-    "twitchClientSecret": "your_twitch_client_secret"
-}

--- a/index.js
+++ b/index.js
@@ -3,6 +3,10 @@ const fetch = require('node-fetch');
 const fs = require('fs');
 const path = require('path');
 const { Client, GatewayIntentBits, Collection, REST, Routes, ActivityType } = require('discord.js');
+const config = require('./config.json');
+const checkBlueskyPosts = require('./commands/checkBlueskyPosts');
+const checkTwitchStreams = require('./commands/checkTwitchStreams');
+const { getCounter, setCounter } = require('./utils/counter');
 
 const app = express();
 const client = new Client({
@@ -29,13 +33,13 @@ for (const file of commandFiles) {
 }
 
 // Enregistrer les commandes slash pour chaque serveur
-const rest = new REST({ version: '10' }).setToken(process.env.DISCORD_TOKEN);
+const rest = new REST({ version: '10' }).setToken(config.token);
 
 const registerCommands = async (guildId) => {
     try {
         console.log(`Enregistrement des commandes slash pour le serveur ${guildId}...`);
         await rest.put(
-            Routes.applicationGuildCommands(process.env.DISCORD_CLIENT_ID, guildId),
+            Routes.applicationGuildCommands(config.clientId, guildId),
             { body: client.commands.map(command => command.data.toJSON()) }
         );
         console.log(`Commandes slash enregistrées avec succès pour le serveur ${guildId}.`);
@@ -85,7 +89,7 @@ const getTwitchOAuthToken = async (guildId) => {
     const serverConfig = JSON.parse(fs.readFileSync('serverConfig.json', 'utf8'));
     if (!serverConfig.servers[guildId].twitchOAuthToken) {
         try {
-            const response = await fetch(`https://id.twitch.tv/oauth2/token?client_id=${process.env.TWITCH_CLIENT_ID}&client_secret=${process.env.TWITCH_CLIENT_SECRET}&grant_type=client_credentials`, {
+            const response = await fetch(`https://id.twitch.tv/oauth2/token?client_id=${config.twitchClientId}&client_secret=${config.twitchClientSecret}&grant_type=client_credentials`, {
                 method: 'POST'
             });
             const data = await response.json();
@@ -117,12 +121,12 @@ const ensureConfigFile = () => {
     const configPath = path.join(__dirname, 'config.json');
     if (!fs.existsSync(configPath)) {
         const initialConfig = {
-            token: process.env.DISCORD_TOKEN || 'your_discord_bot_token',
-            clientId: process.env.DISCORD_CLIENT_ID || 'your_discord_client_id',
-            blueskyHandle: process.env.BLUESKY_HANDLE || 'your_bluesky_handle',
-            blueskyAppPassword: process.env.BLUESKY_APP_PASSWORD || 'your_bluesky_app_password',
-            twitchClientId: process.env.TWITCH_CLIENT_ID || 'your_twitch_client_id',
-            twitchClientSecret: process.env.TWITCH_CLIENT_SECRET || 'your_twitch_client_secret'
+            token: config.token || 'your_discord_bot_token',
+            clientId: config.clientId || 'your_discord_client_id',
+            blueskyHandle: config.blueskyHandle || 'your_bluesky_handle',
+            blueskyAppPassword: config.blueskyAppPassword || 'your_bluesky_app_password',
+            twitchClientId: config.twitchClientId || 'your_twitch_client_id',
+            twitchClientSecret: config.twitchClientSecret || 'your_twitch_client_secret'
         };
         fs.writeFileSync(configPath, JSON.stringify(initialConfig, null, 2));
         console.log('Fichier config.json créé.');
@@ -154,7 +158,7 @@ client.once('ready', async () => {
         const start = Date.now();
         await fetch('https://discord.com/api/v10/users/@me', {
             headers: {
-                Authorization: `Bot ${process.env.DISCORD_TOKEN}`
+                Authorization: `Bot ${config.token}`
             }
         });
         const end = Date.now();
@@ -244,6 +248,30 @@ client.on('interactionCreate', async interaction => {
     } catch (error) {
         console.error(error);
         await interaction.reply({ content: 'Il y a eu une erreur en essayant d\'exécuter cette commande.', ephemeral: true });
+    }
+});
+
+client.on('messageCreate', async message => {
+    if (message.author.bot) return;
+
+    const { count, lastUser } = getCounter();
+    const expectedNumber = count + 1;
+
+    if (message.content === expectedNumber.toString()) {
+        if (lastUser === message.author.id) {
+            setCounter(0, null);
+            await message.react('❌');
+            await message.reply('Une même personne ne peut pas répondre deux fois. On recommence de zéro !');
+        } else {
+            setCounter(expectedNumber, message.author.id);
+            await message.react('✅');
+        }
+    } else if (message.content !== expectedNumber.toString() && lastUser === message.author.id) {
+        setCounter(0, null);
+        await message.react('❌');
+        await message.reply('Le compteur reprend à zéro ! Recommençons.');
+    } else {
+        await message.react('❌');
     }
 });
 

--- a/index.js
+++ b/index.js
@@ -3,9 +3,6 @@ const fetch = require('node-fetch');
 const fs = require('fs');
 const path = require('path');
 const { Client, GatewayIntentBits, Collection, REST, Routes, ActivityType } = require('discord.js');
-const config = require('./config.json');
-const checkBlueskyPosts = require('./commands/checkBlueskyPosts');
-const checkTwitchStreams = require('./commands/checkTwitchStreams');
 
 const app = express();
 const client = new Client({
@@ -32,13 +29,13 @@ for (const file of commandFiles) {
 }
 
 // Enregistrer les commandes slash pour chaque serveur
-const rest = new REST({ version: '10' }).setToken(config.token);
+const rest = new REST({ version: '10' }).setToken(process.env.DISCORD_TOKEN);
 
 const registerCommands = async (guildId) => {
     try {
         console.log(`Enregistrement des commandes slash pour le serveur ${guildId}...`);
         await rest.put(
-            Routes.applicationGuildCommands(config.clientId, guildId),
+            Routes.applicationGuildCommands(process.env.DISCORD_CLIENT_ID, guildId),
             { body: client.commands.map(command => command.data.toJSON()) }
         );
         console.log(`Commandes slash enregistrées avec succès pour le serveur ${guildId}.`);
@@ -88,7 +85,7 @@ const getTwitchOAuthToken = async (guildId) => {
     const serverConfig = JSON.parse(fs.readFileSync('serverConfig.json', 'utf8'));
     if (!serverConfig.servers[guildId].twitchOAuthToken) {
         try {
-            const response = await fetch(`https://id.twitch.tv/oauth2/token?client_id=${config.twitchClientId}&client_secret=${config.twitchClientSecret}&grant_type=client_credentials`, {
+            const response = await fetch(`https://id.twitch.tv/oauth2/token?client_id=${process.env.TWITCH_CLIENT_ID}&client_secret=${process.env.TWITCH_CLIENT_SECRET}&grant_type=client_credentials`, {
                 method: 'POST'
             });
             const data = await response.json();
@@ -113,6 +110,22 @@ const ensureEventsFile = () => {
     if (!fs.existsSync(eventsPath)) {
         fs.writeFileSync(eventsPath, JSON.stringify({}, null, 2));
         console.log('Fichier events.json créé.');
+    }
+};
+
+const ensureConfigFile = () => {
+    const configPath = path.join(__dirname, 'config.json');
+    if (!fs.existsSync(configPath)) {
+        const initialConfig = {
+            token: process.env.DISCORD_TOKEN || 'your_discord_bot_token',
+            clientId: process.env.DISCORD_CLIENT_ID || 'your_discord_client_id',
+            blueskyHandle: process.env.BLUESKY_HANDLE || 'your_bluesky_handle',
+            blueskyAppPassword: process.env.BLUESKY_APP_PASSWORD || 'your_bluesky_app_password',
+            twitchClientId: process.env.TWITCH_CLIENT_ID || 'your_twitch_client_id',
+            twitchClientSecret: process.env.TWITCH_CLIENT_SECRET || 'your_twitch_client_secret'
+        };
+        fs.writeFileSync(configPath, JSON.stringify(initialConfig, null, 2));
+        console.log('Fichier config.json créé.');
     }
 };
 
@@ -141,7 +154,7 @@ client.once('ready', async () => {
         const start = Date.now();
         await fetch('https://discord.com/api/v10/users/@me', {
             headers: {
-                Authorization: `Bot ${config.token}`
+                Authorization: `Bot ${process.env.DISCORD_TOKEN}`
             }
         });
         const end = Date.now();
@@ -233,6 +246,12 @@ client.on('interactionCreate', async interaction => {
         await interaction.reply({ content: 'Il y a eu une erreur en essayant d\'exécuter cette commande.', ephemeral: true });
     }
 });
+
+// Assurez-vous que le fichier config.json est présent
+ensureConfigFile();
+
+// Charger le fichier config.json
+const config = require('./config.json');
 
 client.login(config.token);
 

--- a/utils/counter.js
+++ b/utils/counter.js
@@ -1,0 +1,19 @@
+const fs = require('fs');
+const path = require('path');
+
+const COUNTER_FILE = path.join(__dirname, '../counter.json');
+
+function getCounter() {
+    if (fs.existsSync(COUNTER_FILE)) {
+        return JSON.parse(fs.readFileSync(COUNTER_FILE, 'utf8'));
+    } else {
+        return { count: 0, lastUser: null };
+    }
+}
+
+function setCounter(count, lastUser) {
+    const counter = { count, lastUser };
+    fs.writeFileSync(COUNTER_FILE, JSON.stringify(counter, null, 2));
+}
+
+module.exports = { getCounter, setCounter };


### PR DESCRIPTION
This pull request introduces a new counter game feature to the Discord bot and includes several changes to support this functionality. The most important changes include adding a new command to start the counter game, handling message interactions to increment the counter, and ensuring configuration file creation.

New command and interaction handling:

* [`commands/startCounter.js`](diffhunk://#diff-45a0c6180e05d095ccea1c146997ce362bebc4ce592fa3ea5d7021406ec25ee6R1-R19): Added a new command `startcounter` to start the counter game in a specified channel.
* [`index.js`](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346R254-R283): Added an event listener for `messageCreate` to handle the counter game logic, including incrementing the counter and resetting it under specific conditions.

Configuration file management:

* [`index.js`](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346R120-R135): Added a function `ensureConfigFile` to create a `config.json` file with default values if it does not exist.

Utility functions for counter game:

* [`utils/counter.js`](diffhunk://#diff-dc4f4f6b9ec0b25c9071dbac61783bc56007345626ab17e02c82deb0d63fd43bR1-R19): Added utility functions `getCounter` and `setCounter` to manage the counter state using a JSON file.

Removal of example configuration:

* [`exemple_config.json`](diffhunk://#diff-0f37477d76611446bc502295795c6c04003ecf899e7319b0aeab08cd12f5152bL1-L8): Removed the example configuration file.